### PR TITLE
render Date types on gallery preview

### DIFF
--- a/src/components/GalleryComposer.js
+++ b/src/components/GalleryComposer.js
@@ -9,8 +9,13 @@ export default class GalleryComposer extends Component {
       // is this answer multiple choice?
 
       let answerBody
+      const possibleDate = new Date(a.answer.answer.value)
+      const months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
 
-      if (Array.isArray(a.answer.answer.options)) {
+      if (Object.prototype.toString.call(possibleDate) === '[object Date]' && !isNaN(possibleDate)) {
+        const formatted = `${possibleDate.getDate()} ${months[possibleDate.getMonth()]}. ${possibleDate.getFullYear()}`
+        answerBody = <span className='askGallery__answerText'>{formatted}</span>
+      } else if (Array.isArray(a.answer.answer.options)) {
         answerBody = a.answer.answer.options.map(option => {
           return <div className='askGallery__answerMultiOption'>{option.title}</div>
         })


### PR DESCRIPTION
## What?

fixes https://github.com/coralproject/ask/issues/25

Date types have a different way to get the response copy. This PR allows for Date types to be rendered in the Gallery Preview
## How to test
- go to a gallery with date responses like {{cayHost}}/579672167bb36b00072d9c49/gallery
- click Preview
- dates should show up as `Day Mo. Year`
