### PR TITLE
make sure elkhorn doesn't need node6 yet

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -106,7 +106,9 @@ app.post('/gallery/:galleryId/publish', (req, res) => {
     builder.buildGallery(req.body).then(build => {
       return Promise.all([upload(req.params.galleryId, build.code), build])
     }).then(results => {
-      const [url, build] = results
+      const url = results[0]
+      const build = results[1]
+
       res.json({url, build})
     })
     .catch(error => {


### PR DESCRIPTION
there's only one line that makes Elkhorn require node >= v6. That seems silly.

This PR reverts things so there's no destructuring in non-babelified code
