### PR TITLE
Set minimal build as a setting

### DIFF
--- a/config.sample.json
+++ b/config.sample.json
@@ -6,5 +6,6 @@
     "region": "",
     "accessKeyId": "",
     "secretAccessKey": ""
-  }
+  },
+  "minimalWidgets": false
 }

--- a/server/builder.js
+++ b/server/builder.js
@@ -8,6 +8,7 @@ var replace = require('rollup-plugin-replace')
 var commonjs = require('rollup-plugin-commonjs')
 var babelConf = require('./babel.json')
 var log = require('./logger')
+var config = require('../config.json')
 
 var defaultBundle
 createFormBundle().then(function (bundle) {
@@ -68,7 +69,7 @@ module.exports = {
     log(JSON.stringify(props))
     return new Promise(function (resolve, reject) {
       log('Starting rollup')
-      var getBundle = isPreview ? getDefaultBundle : createFormBundle
+      var getBundle = isPreview || !config.minimalWidgets ? getDefaultBundle : createFormBundle
       getBundle(props)
       .then(function (bundle) {
         log('Built bundle')


### PR DESCRIPTION
Introduces a config property called `minimalWidgets`. If setting to true it creates a minimal widget (only builds the widgets used on the ask) but it takes some seconds. If disabled (default) the js size it's a little bigger (depending on the installed components) but takes miliseconds

![condition](https://cloud.githubusercontent.com/assets/165799/17630901/928b8502-608f-11e6-8c05-b731cd384c0f.gif)
